### PR TITLE
add standard dlog mode

### DIFF
--- a/src/main/scala/nl/biopet/utils/biowdl/Pipeline.scala
+++ b/src/main/scala/nl/biopet/utils/biowdl/Pipeline.scala
@@ -62,7 +62,7 @@ trait Pipeline extends BiopetTest with Logging {
     outputDir.mkdir()
     val inputsFile = Pipeline.writeInputs(outputDir, inputs)
 
-    val javaCmd = Seq("java") ++ cromwellConfig
+    val javaCmd = Seq("java", "-DLOG_MODE=standard") ++ cromwellConfig
       .map(c => s"-Dconfig.file=${c.getAbsolutePath}")
       .toSeq
 


### PR DESCRIPTION
### Description

This will prevent the written logs from having escape codes for coloring.

----

### Checklist (never delete this)

- [ ] Each method/class/object/trait should have scaladocs
- [ ] Added methods are unit tested
- [ ] Test coverage may not drop
- [ ] Documentation should be updated if required
